### PR TITLE
Fix remaining build failures found by a full pio run across all envs

### DIFF
--- a/examples/simple_repeater/wifimqtt.cpp
+++ b/examples/simple_repeater/wifimqtt.cpp
@@ -281,7 +281,6 @@ bool WiFiMQTT::connectWiFi() {
       }
       time_t now = time(nullptr);
       if (now > 1700000000) {
-        extern AutoDiscoverRTCClock rtc_clock;
         rtc_clock.setCurrentTime((uint32_t)now);
         Serial.printf(" OK (%lu)\n", (unsigned long)now);
       } else {

--- a/platformio.ini
+++ b/platformio.ini
@@ -57,7 +57,7 @@ build_src_filter =
 extends = arduino_base
 platform = platformio/espressif32@6.11.0
 monitor_filters = esp32_exception_decoder, clock_sync
-extra_scripts = merge-bin.py
+extra_scripts = post:merge_firmware.py
 build_flags = ${arduino_base.build_flags}
   -D ESP32_PLATFORM
 ;  -D ESP32_CPU_FREQ=80          ; change it to your need

--- a/variants/lilygo_t5s3_epaper_pro/platformio.ini
+++ b/variants/lilygo_t5s3_epaper_pro/platformio.ini
@@ -185,6 +185,7 @@ build_src_filter = ${LilyGo_T5S3_EPaper_Pro.build_src_filter}
   +<../examples/simple_repeater/*.cpp>
 build_flags =
   ${LilyGo_T5S3_EPaper_Pro.build_flags}
+  -I examples/companion_radio/ui-new
   -D FIRMWARE_VERSION='"Meck T5S3 WiFi Rptr v0.1"'
   -D FIRMWARE_BUILD_DATE='"5 Apr 2026"'
   -D DISPLAY_CLASS=FastEPDDisplay

--- a/variants/lilygo_tdeck_pro/platformio.ini
+++ b/variants/lilygo_tdeck_pro/platformio.ini
@@ -334,6 +334,7 @@ extends = LilyGo_TDeck_Pro
 build_flags =
   ${LilyGo_TDeck_Pro.build_flags}
   -I examples/simple_repeater
+  -I examples/companion_radio/ui-new
   -D ADMIN_PASSWORD='"admin"'
   -D HAS_4G_MODEM=1
   -D DISABLE_WIFI_OTA=1
@@ -393,6 +394,7 @@ build_src_filter = ${LilyGo_TDeck_Pro.build_src_filter}
   +<../examples/simple_repeater/*.cpp>
 build_flags =
   ${LilyGo_TDeck_Pro.build_flags}
+  -I examples/companion_radio/ui-new
   -D FIRMWARE_VERSION='"Meck WiFi Rptr v0.3"'
   -D FIRMWARE_BUILD_DATE='"5 April 2026"'
   -D MAX_NEIGHBOURS=50


### PR DESCRIPTION
A complete `pio run` (all 16 environments) on Linux turned up 6 failures beyond the case-sensitive-include fix

1. meck_remote_repeater, meck_wifi_repeater, meck_wifi_repeater_t5s3 compile GxEPDDisplay.cpp / FastEPDDisplay.cpp, which #include MeckFonts.h whenever HAS_MECK_FONTS is defined. HAS_MECK_FONTS is set at the shared variant-base level (so all envs in that variant inherit it), but the `-I examples/companion_radio/ui-new` include path needed to find MeckFonts.h was only added to the companion-radio envs, not the repeater envs in the same file. Added the missing -I flag to the three repeater env sections.

2. meck_wifi_repeater_heltec_v3/v4/v4_headless failed with "missing SConscript file 'merge-bin.py'". esp32_base's extra_scripts still pointed at merge-bin.py, which was deleted in 451f4b01 ("remove redundant merge script"). Other variants override extra_scripts themselves so they never hit the stale base default; the Heltec variants don't, so they inherited the broken reference. Pointed esp32_base at merge_firmware.py instead, matching every variant that already sets this explicitly.

3. After fix #1, meck_wifi_repeater_t5s3 still failed: wifimqtt.cpp had a hardcoded `extern AutoDiscoverRTCClock rtc_clock;`, but the T5S3 variant declares its global rtc_clock as PCF85063Clock (a different concrete RTCClock subclass) in target.h. The local extern was redundant anyway, since target.h is already included at the top of this file and declares the correctly-typed global for whichever variant is being built. Removed the stale extern so the call resolves through the existing declaration.

Verified: `pio run` now succeeds for all 16 environments.